### PR TITLE
按返回键会dismiss对话框，导致内存泄漏

### DIFF
--- a/YCDialogLib/src/main/java/com/pedaily/yc/ycdialoglib/fragment/BaseDialogFragment.java
+++ b/YCDialogLib/src/main/java/com/pedaily/yc/ycdialoglib/fragment/BaseDialogFragment.java
@@ -229,8 +229,8 @@ public abstract class BaseDialogFragment extends DialogFragment {
     public static void dismissDialog(){
         if(dialog!=null && dialog.isShowing()){
             dialog.dismiss();
-            dialog = null;
         }
+        dialog = null;
     }
 
 


### PR DESCRIPTION
按返回键默认执行`cancel()`，`cancel()`会执行`dismiss()`，所以此时`dialog.isShowing()==false`，最终`BaseDialogFragment.onDestroy()`里不会执行到`dialog = null;`，从而导致内存泄漏。